### PR TITLE
[feature] accesion only

### DIFF
--- a/chromsize/src/cli.rs
+++ b/chromsize/src/cli.rs
@@ -36,4 +36,12 @@ pub struct Args {
         default_value_t = num_cpus::get()
     )]
     pub threads: usize,
+
+    #[clap(
+        short = 'a',
+        long = "accession-only",
+        help = "only keep the accession id part of the header (stop after blank)",
+        default_value_t = false
+    )]
+    pub accession_only: bool,
 }

--- a/chromsize/src/main.rs
+++ b/chromsize/src/main.rs
@@ -13,6 +13,6 @@ fn main() {
         .build_global()
         .unwrap();
 
-    let sizes = get_sizes(args.fasta).expect("ERROR. Could not get sizes:");
+    let sizes = get_sizes(args.fasta, args.accession_only).expect("ERROR. Could not get sizes:");
     writer(sizes, args.out);
 }


### PR DESCRIPTION
- a lot of fasta variants allow very long and descriptive headers
- splits the header at the first space character and only uses that in the left column of the output